### PR TITLE
Fix incorrect property in metadata helper

### DIFF
--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -16,14 +16,14 @@ export const twitterMetadata = ({
   title?: string;
   description?: string;
   url: string;
-}) => ({
-  'og:site_name': Configs.site_title,
-  'og:url': Configs.base_url + url,
-  'og:title': title ? [title, Configs.site_title].join(' | ') : '',
-  'og:description': description ? description : Configs.site_descriptio,
-  'og:image': Configs.base_url + '/og_image.png',
-  'og:type': 'article',
-});
+  }) => ({
+    'og:site_name': Configs.site_title,
+    'og:url': Configs.base_url + url,
+    'og:title': title ? [title, Configs.site_title].join(' | ') : '',
+    'og:description': description ? description : Configs.site_description,
+    'og:image': Configs.base_url + '/og_image.png',
+    'og:type': 'article',
+  });
 
 export const openGraphMetadata = ({
   title,


### PR DESCRIPTION
## Summary
- fix wrong property name in `twitterMetadata` helper

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffea9fbc0832cbb9b4f64099cd123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a typo in the site description for Twitter metadata to ensure accurate information is displayed when sharing links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->