### PR TITLE
fix: correct consultant keyword

### DIFF
--- a/config.js
+++ b/config.js
@@ -24,7 +24,7 @@ const Configs = {
     { keyword: 'Typescript' },
     { keyword: 'Golang' },
     { keyword: 'Consulenza' },
-    { keyword: 'Consultat' },
+    { keyword: 'Consultant' },
     { keyword: 'Roma' },
     { keyword: 'Italia' },
   ],


### PR DESCRIPTION
## Summary
- correct the Consultant keyword spelling in `config.js`

## Testing
- `npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true config.js` *(fails: 403 Forbidden when fetching from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68400b41d668832cb95aa8a43edafc21